### PR TITLE
Change require locallib path from dataroot to dirroot

### DIFF
--- a/view.php
+++ b/view.php
@@ -21,7 +21,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 require_once("../../config.php");
-require_once($CFG->dataroot."/mod/hvp/locallib.php");
+require_once($CFG->dirroot."/mod/hvp/locallib.php");
 
 global $PAGE, $DB, $CFG, $OUTPUT;
 


### PR DESCRIPTION
Cool filter. Just had a play and it wasn't working when trying to embed h5p modules. I think the locallib is supposed to be required from dirroot but dataroot is specified.